### PR TITLE
Fixed README Installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 #### Installation
 ```gradle
 dependencies {
-  compile "io.ashdavies.rxfirebase:{latest-version}"
+  compile "io.ashdavies.rx:rx-firebase:{latest-version}"
 }
 ```
 


### PR DESCRIPTION
The dependency name was wrong. It took me a while to find the correct one on Bintray. As a word of advice: If you are gonna publish an OS project you should enable the issues section on Github.