### PR TITLE
Updated library to latest RxJava and RxAndroid versions

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -11,8 +11,8 @@ ext {
             'androidCommons': '0.5.6',
             'androidSupport': '25.1.1',
 
-            'rxAndroid'     : '2.0.0-RC1',
-            'rxJava'        : '2.0.0-RC2',
+            'rxAndroid'     : '2.0.1',
+            'rxJava'        : '2.0.5',
             'rxTasks'       : '1.1.3',
 
             'firebase'      : '10.0.1',

--- a/library/src/main/java/io/ashdavies/rx/rxfirebase/ChildEventClassTransformer.java
+++ b/library/src/main/java/io/ashdavies/rx/rxfirebase/ChildEventClassTransformer.java
@@ -14,9 +14,8 @@ class ChildEventClassTransformer<T> implements FlowableTransformer<ChildEvent, T
     this.kls = kls;
   }
 
-  @Override
-  public Publisher<? extends T> apply(Flowable<ChildEvent> source) throws Exception {
-    return source.map(new Mapper<>(kls));
+  @Override public Publisher<T> apply(Flowable<ChildEvent> upstream) {
+    return upstream.map(new Mapper<>(kls));
   }
 
   private static class Mapper<T> implements Function<ChildEvent, T> {

--- a/library/src/main/java/io/ashdavies/rx/rxfirebase/RxFirebaseAuth.java
+++ b/library/src/main/java/io/ashdavies/rx/rxfirebase/RxFirebaseAuth.java
@@ -10,9 +10,9 @@ import com.google.firebase.auth.ProviderQueryResult;
 
 import io.ashdavies.rx.common.NullableMaybeOnSubscribe;
 import io.ashdavies.rx.rxtasks.RxTasks;
+import io.reactivex.BackpressureStrategy;
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
-import io.reactivex.FlowableEmitter;
 import io.reactivex.Maybe;
 import io.reactivex.Single;
 
@@ -34,7 +34,7 @@ public final class RxFirebaseAuth {
 
   @CheckResult
   public Flowable<FirebaseAuth> authStateChanged() {
-    return Flowable.create(new AuthStateOnSubscribe(auth), FlowableEmitter.BackpressureMode.BUFFER);
+    return Flowable.create(new AuthStateOnSubscribe(auth), BackpressureStrategy.BUFFER);
   }
 
   @CheckResult

--- a/library/src/main/java/io/ashdavies/rx/rxfirebase/RxFirebaseDatabase.java
+++ b/library/src/main/java/io/ashdavies/rx/rxfirebase/RxFirebaseDatabase.java
@@ -12,9 +12,9 @@ import com.google.firebase.database.Query;
 import java.util.Map;
 
 import io.ashdavies.rx.rxtasks.RxTasks;
+import io.reactivex.BackpressureStrategy;
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
-import io.reactivex.FlowableEmitter;
 import io.reactivex.Single;
 
 @SuppressWarnings("WeakerAccess")
@@ -69,7 +69,7 @@ public final class RxFirebaseDatabase {
 
   @CheckResult
   public Flowable<DataSnapshot> onValueEvent() {
-    return Flowable.create(new ValueEventOnSubscribe(reference), FlowableEmitter.BackpressureMode.BUFFER);
+    return Flowable.create(new ValueEventOnSubscribe(reference), BackpressureStrategy.BUFFER);
   }
 
   @CheckResult
@@ -79,7 +79,7 @@ public final class RxFirebaseDatabase {
 
   @CheckResult
   public Flowable<ChildEvent> onChildEvent() {
-    return Flowable.create(new ChildEventOnSubscribe(reference), FlowableEmitter.BackpressureMode.BUFFER);
+    return Flowable.create(new ChildEventOnSubscribe(reference), BackpressureStrategy.BUFFER);
   }
 
   @CheckResult

--- a/library/src/main/java/io/ashdavies/rx/rxfirebase/SetValueCompletionCompletable.java
+++ b/library/src/main/java/io/ashdavies/rx/rxfirebase/SetValueCompletionCompletable.java
@@ -15,7 +15,7 @@ class SetValueCompletionCompletable implements DatabaseReference.CompletionListe
 
   @Override
   public void onComplete(DatabaseError error, DatabaseReference reference) {
-    if (emitter.isCancelled()) {
+    if (emitter.isDisposed()) {
       return;
     }
 

--- a/library/src/test/java/io/ashdavies/rx/rxfirebase/SetValueCompletionCompletableTest.java
+++ b/library/src/test/java/io/ashdavies/rx/rxfirebase/SetValueCompletionCompletableTest.java
@@ -35,7 +35,7 @@ public class SetValueCompletionCompletableTest {
 
   @Test
   public void shouldNotEmitIfCancelled() throws Exception {
-    given(emitter.isCancelled()).willReturn(true);
+    given(emitter.isDisposed()).willReturn(true);
 
     completable.onComplete(null, reference);
     completable.onComplete(error, null);

--- a/library/src/test/java/io/ashdavies/rx/rxfirebase/SetValueOnSubscribeTest.java
+++ b/library/src/test/java/io/ashdavies/rx/rxfirebase/SetValueOnSubscribeTest.java
@@ -36,7 +36,7 @@ public class SetValueOnSubscribeTest {
 
   @Test
   public void shouldSetValueListener() throws Exception {
-    given(emitter.isCancelled()).willReturn(false);
+    given(emitter.isDisposed()).willReturn(false);
 
     onSubscribe.subscribe(emitter);
     verify(reference).setValue(eq(DIGESTIVES), isNull(), captor.capture());


### PR DESCRIPTION
This project was using the 2.0.0-RC2 version and RxJava 2 suffered some breaking changes in its API before hitting 2.0 stable. Updated the code to make it compatible with the latest RxJava API version. Tests are all passing.